### PR TITLE
Created Granular Synth classes, currently equivalent to the Sampler

### DIFF
--- a/Nave.jucer
+++ b/Nave.jucer
@@ -3,6 +3,22 @@
 <JUCERPROJECT id="SyQ9g4" name="Nave" projectType="guiapp" jucerVersion="5.4.5">
   <MAINGROUP id="ZqHcS3" name="Nave">
     <GROUP id="{C3E1973A-F9A9-EA2C-7C06-AC04BFDFD624}" name="Source">
+      <FILE id="hDRftg" name="GranularSynthesizer.cpp" compile="1" resource="0"
+            file="Source/GranularSynthesizer.cpp"/>
+      <FILE id="eC6mvR" name="GranularSynthesizer.h" compile="0" resource="0"
+            file="Source/GranularSynthesizer.h"/>
+      <FILE id="bAGXsj" name="GranularVoice.cpp" compile="1" resource="0"
+            file="Source/GranularVoice.cpp"/>
+      <FILE id="Fy5Fi4" name="GranularVoice.h" compile="0" resource="0" file="Source/GranularVoice.h"/>
+      <FILE id="lViSPn" name="GranularSound.cpp" compile="1" resource="0"
+            file="Source/GranularSound.cpp"/>
+      <FILE id="Sw1kLZ" name="GranularSound.h" compile="0" resource="0" file="Source/GranularSound.h"/>
+      <FILE id="oeXpAY" name="Sampler.cpp" compile="1" resource="0" file="Source/Sampler.cpp"/>
+      <FILE id="F9T1pO" name="Sampler.h" compile="0" resource="0" file="Source/Sampler.h"/>
+      <FILE id="KEYdNu" name="GranularAudioSource.cpp" compile="1" resource="0"
+            file="Source/GranularAudioSource.cpp"/>
+      <FILE id="ITP0h4" name="GranularAudioSource.h" compile="0" resource="0"
+            file="Source/GranularAudioSource.h"/>
       <FILE id="UPgFZr" name="SynthAudioSource.cpp" compile="1" resource="0"
             file="Source/SynthAudioSource.cpp"/>
       <FILE id="JCtpP0" name="SynthAudioSource.h" compile="0" resource="0"

--- a/Source/GranularAudioSource.cpp
+++ b/Source/GranularAudioSource.cpp
@@ -1,0 +1,67 @@
+/*
+  ==============================================================================
+
+    GranularAudioSource.cpp
+    Created: 18 Dec 2019 2:53:49pm
+    Author:  Bennet Leff
+
+  ==============================================================================
+*/
+
+#include "../JuceLibraryCode/JuceHeader.h"
+#include "GranularAudioSource.h"
+
+//==============================================================================
+GranularAudioSource::GranularAudioSource(MidiKeyboardState& keyState)
+    : keyboardState(keyState)
+{
+    for(auto i = 0; i < 4; ++i)
+        synth.addVoice(new SamplerVoice());
+}
+
+
+
+//==============================================================================
+void GranularAudioSource::setSourceFile(const File& newFile)
+{
+    sourceFile = newFile;
+
+    AudioFormatManager formatManager;
+    formatManager.registerBasicFormats();
+
+    auto* reader = formatManager.createReaderFor (sourceFile); 
+
+    AudioSampleBuffer fileBuffer;
+
+    if (reader != nullptr)
+    {
+        auto duration = reader->lengthInSamples / reader->sampleRate;
+
+        if (duration < 4)
+        {
+            fileBuffer.setSize (reader->numChannels, (int) reader->lengthInSamples);
+            reader->read (&fileBuffer,
+                          0,
+                          (int) reader->lengthInSamples,
+                          0,
+                          true,
+                          true);
+        }
+        else
+        {
+            // handle the error that the file is 4 seconds or longer..
+        }
+    }
+    
+    allNotes.setRange(0, 128, true);
+    
+    auto samplerSound = new SamplerSound("Sample", *reader, allNotes, 64, 0.05, 2.0, 4.0);
+    
+    delete reader;
+    
+    synth.addSound(samplerSound);
+}
+
+void GranularAudioSource::releaseResources()
+{
+}

--- a/Source/GranularAudioSource.h
+++ b/Source/GranularAudioSource.h
@@ -1,0 +1,114 @@
+/*
+  ==============================================================================
+
+    GranularAudioSource.h
+    Created: 18 Dec 2019 2:53:49pm
+    Author:  Bennet Leff
+    
+  ==============================================================================
+*/
+
+#pragma once
+
+#include "../JuceLibraryCode/JuceHeader.h"
+
+//==============================================================================
+
+
+/*
+ * The Attack, Sustain, and Release of a Grain are necessary parameters
+ * as grains should have some crossfading in volume between each other.
+ * This splits the grains total duration into three phases which
+ * the volume of the grain should be modulated by.
+ * For instance if the grain size is 10 ms, attack might be 2ms,
+ * and release could be 1ms. Then sustain would be 7ms.
+ *
+ * For these values I'll test linear attack and release,
+ * as well as an updated version with a gain multiplier
+ * equivalent to either the Guassian curve or the Quasi-Guassian
+ * which is described as the Tukey window in Roads' "The Computer
+ * Music Tutorial"
+ */
+struct GrainASR
+{
+    int attack;
+    int sustain;
+    int release;
+};
+
+/*
+ * The GranularAudioSource should be similar to the SamplerAudioSource.
+ * It is no longer leverages the SamplerSound and SamplerVoice classes but
+ * instead overrides them. This enables more advanced functionality such as
+ * moving the start and stop positions around throughout the sound.
+ * Additionally, this will allow us to buffer the files data (which is itself a
+ * buffer) into grains.
+ *
+ * We can store grains in a table for more efficient playback or we can just
+ * store the grains start and stop positions in a table for lookup. We'll start
+ * with storing stop and start positions though caching buffers may become useful
+ * later as the synth is expanded.
+ *
+ * For the time being, the method of Quasi-Synchronous Granular Synthesis, will be
+ * what this class implements.
+ */
+class GranularAudioSource    : public AudioSource
+{
+public:
+    GranularAudioSource(MidiKeyboardState& keyState);
+        
+        void setUsingSamplerSound()
+        {
+            synth.clearSounds();
+        }
+        
+        void prepareToPlay(int samplesPerBlockExpected, double sampleRate) override
+        {
+            synth.setCurrentPlaybackSampleRate (sampleRate);
+            midiCollector.reset (sampleRate);
+        }
+        
+        void releaseResources() override;
+        
+        void getNextAudioBlock(const AudioSourceChannelInfo& bufferToFill) override
+        {
+            bufferToFill.clearActiveBufferRegion();
+            
+            MidiBuffer incomingMidi;
+            midiCollector.removeNextBlockOfMessages(incomingMidi, bufferToFill.numSamples);
+            
+            keyboardState.processNextMidiBuffer(incomingMidi, bufferToFill.startSample, bufferToFill.numSamples, true);
+            
+            synth.renderNextBlock(*bufferToFill.buffer, incomingMidi,
+                                  bufferToFill.startSample, bufferToFill.numSamples);
+        }
+        
+        MidiMessageCollector* getMidiCollector()
+        {
+            return &midiCollector;
+        }
+            
+        void setSourceFile(const File& newFile);
+        
+    private:
+        
+    
+    
+
+private:
+    // Assuming a constant grain size for each grain.
+    int grainSize;
+    
+    // Fields for MIDI interaction
+    MidiKeyboardState& keyboardState;
+    MidiMessageCollector midiCollector;
+    Synthesiser synth;
+    
+    // allNotes will be a range of 0-127
+    BigInteger allNotes;
+    
+    // The source file or sample we want to "granulate"
+    File sourceFile;
+    
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (GranularAudioSource)
+};

--- a/Source/GranularSound.cpp
+++ b/Source/GranularSound.cpp
@@ -1,0 +1,51 @@
+/*
+  ==============================================================================
+
+    GranularSound.cpp
+    Created: 18 Dec 2019 5:04:57pm
+    Author:  Bennet Leff
+
+  ==============================================================================
+*/
+
+#include "GranularSound.h"
+
+GranularSound::GranularSound (const String& soundName,
+                            AudioFormatReader& source,
+                            const BigInteger& notes,
+                            int midiNoteForNormalPitch,
+                            double attackTimeSecs,
+                            double releaseTimeSecs,
+                            double maxSampleLengthSeconds)
+    : name (soundName),
+      sourceSampleRate (source.sampleRate),
+      midiNotes (notes),
+      midiRootNote (midiNoteForNormalPitch)
+{
+    if (sourceSampleRate > 0 && source.lengthInSamples > 0)
+    {
+        length = jmin ((int) source.lengthInSamples,
+                       (int) (maxSampleLengthSeconds * sourceSampleRate));
+
+        data.reset (new AudioBuffer<float> (jmin (2, (int) source.numChannels), length + 4));
+
+        source.read (data.get(), 0, length + 4, 0, true, true);
+
+        params.attack  = static_cast<float> (attackTimeSecs);
+        params.release = static_cast<float> (releaseTimeSecs);
+    }
+}
+
+GranularSound::~GranularSound()
+{
+}
+
+bool GranularSound::appliesToNote (int midiNoteNumber)
+{
+    return midiNotes[midiNoteNumber];
+}
+
+bool GranularSound::appliesToChannel (int /*midiChannel*/)
+{
+    return true;
+}

--- a/Source/GranularSound.h
+++ b/Source/GranularSound.h
@@ -1,0 +1,77 @@
+/*
+  ==============================================================================
+
+    GranularSound.h
+    Created: 18 Dec 2019 5:04:57pm
+    Author:  Bennet Leff
+    
+    Code structure heavily borrows from Juce's SamplerSound.
+  ==============================================================================
+*/
+
+#pragma once
+
+#include "../JuceLibraryCode/JuceHeader.h"
+
+class GranularSound : public SynthesiserSound
+{
+public:
+    //==============================================================================
+    /** Creates a sampled sound from an audio reader.
+        This will attempt to load the audio from the source into memory and store
+        it in this object.
+        @param name         a name for the sample
+        @param source       the audio to load. This object can be safely deleted by the
+                            caller after this constructor returns
+        @param midiNotes    the set of midi keys that this sound should be played on. This
+                            is used by the SynthesiserSound::appliesToNote() method
+        @param midiNoteForNormalPitch   the midi note at which the sample should be played
+                                        with its natural rate. All other notes will be pitched
+                                        up or down relative to this one
+        @param attackTimeSecs   the attack (fade-in) time, in seconds
+        @param releaseTimeSecs  the decay (fade-out) time, in seconds
+        @param maxSampleLengthSeconds   a maximum length of audio to read from the audio
+                                        source, in seconds
+    */
+    GranularSound (const String& name,
+                  AudioFormatReader& source,
+                  const BigInteger& midiNotes,
+                  int midiNoteForNormalPitch,
+                  double attackTimeSecs,
+                  double releaseTimeSecs,
+                  double maxSampleLengthSeconds);
+
+    /** Destructor. */
+    ~GranularSound() override;
+
+    //==============================================================================
+    /** Returns the sample's name */
+    const String& getName() const noexcept                  { return name; }
+
+    /** Returns the audio sample data.
+        This could return nullptr if there was a problem loading the data.
+    */
+    AudioBuffer<float>* getAudioData() const noexcept       { return data.get(); }
+
+    //==============================================================================
+    /** Changes the parameters of the ADSR envelope which will be applied to the sample. */
+    void setEnvelopeParameters (ADSR::Parameters parametersToUse)    { params = parametersToUse; }
+
+    //==============================================================================
+    bool appliesToNote (int midiNoteNumber) override;
+    bool appliesToChannel (int midiChannel) override;
+
+private:
+    //==============================================================================
+    friend class GranularVoice;
+
+    String name;
+    std::unique_ptr<AudioBuffer<float>> data;
+    double sourceSampleRate;
+    BigInteger midiNotes;
+    int length = 0, midiRootNote = 0;
+
+    ADSR::Parameters params;
+
+    JUCE_LEAK_DETECTOR (GranularSound)
+};

--- a/Source/GranularSynthesizer.cpp
+++ b/Source/GranularSynthesizer.cpp
@@ -1,0 +1,69 @@
+/*
+  ==============================================================================
+
+    GranularSynthesizer.cpp
+    Created: 18 Dec 2019 5:14:54pm
+    Author:  Bennet Leff
+
+  ==============================================================================
+*/
+
+#include "../JuceLibraryCode/JuceHeader.h"
+#include "GranularSynthesizer.h"
+
+//==============================================================================
+GranularSynthesizer::GranularSynthesizer(MidiKeyboardState& keyboardState)
+        : granularAudioSource(keyboardState),
+          thumbnailCache (5),
+          thumbnail(512, formatManager, thumbnailCache)
+{
+    formatManager.registerBasicFormats();
+    thumbnail.addChangeListener(this);
+}
+
+GranularSynthesizer::~GranularSynthesizer()
+{
+}
+
+void GranularSynthesizer::paint (Graphics& g)
+{
+    g.fillAll (getLookAndFeel().findColour (ResizableWindow::backgroundColourId));   // clear the background
+
+    g.setColour (Colours::grey);
+    g.drawRect (getLocalBounds(), 1);   // draw an outline around the component
+
+    g.setColour (Colours::white);
+    g.setFont (14.0f);
+    g.drawText ("Sampler", getLocalBounds(),
+                Justification::centred, true);   // draw some placeholder text
+    
+    // Painting the audio waveform
+    Rectangle<int> thumbnailBounds (10, 20, getWidth() - 20, getHeight() - 40);
+    
+    if (thumbnail.getNumChannels() == 0)
+        paintIfNoFileLoaded (g, thumbnailBounds);
+    else
+        paintIfFileLoaded (g, thumbnailBounds);
+}
+
+void GranularSynthesizer::resized()
+{
+    // This method is where you should set the bounds of any child
+    // components that your component contains..
+
+}
+
+void GranularSynthesizer::setSourceFile(const File& newFile)
+{
+    granularSourceFile = newFile;
+    granularAudioSource.setSourceFile(newFile);
+    thumbnail.setSource(new FileInputSource(newFile));
+}
+
+void GranularSynthesizer::changeListenerCallback(ChangeBroadcaster *source)
+{
+    if (source == &thumbnail)
+    {
+        repaint();
+    }
+}

--- a/Source/GranularSynthesizer.h
+++ b/Source/GranularSynthesizer.h
@@ -1,0 +1,87 @@
+/*
+  ==============================================================================
+
+    GranularSynthesizer.h
+    Created: 18 Dec 2019 5:14:54pm
+    Author:  Bennet Leff
+
+  ==============================================================================
+*/
+
+#pragma once
+
+#include "../JuceLibraryCode/JuceHeader.h"
+#include "GranularAudioSource.h"
+
+//==============================================================================
+/*
+ * This class wraps the GranularAudioSource class to add GUI functionality.
+ * The GranularAudioSource only handles "Granularizing" sound and playback. This class draws
+ * the AudioThumnail and overlays which allow a user to dictate where the
+ * sample playback begins.
+ * Any other GUI features that are directly related to the use of the GranularSynthesizer
+ * should probably be here as well.
+ */
+class GranularSynthesizer    : public AudioSource, public Component, public ChangeListener
+{
+public:
+    GranularSynthesizer(MidiKeyboardState& keyboardState);
+    ~GranularSynthesizer();
+
+    void paint (Graphics&) override;
+    void resized() override;
+
+    void setSourceFile(const File& newFile);
+    
+    void prepareToPlay(int samplesPerBlockExpected, double sampleRate) override
+    {
+        granularAudioSource.prepareToPlay(samplesPerBlockExpected, sampleRate);
+    }
+    
+    void releaseResources() override { }
+    
+    void getNextAudioBlock(const AudioSourceChannelInfo& bufferToFill) override
+    {
+        granularAudioSource.getNextAudioBlock(bufferToFill);
+    }
+    
+    MidiMessageCollector* getMidiCollector()
+    {
+        return granularAudioSource.getMidiCollector();
+    }
+    
+private:
+    void changeListenerCallback(ChangeBroadcaster* source) override;
+    
+    void paintIfNoFileLoaded (Graphics& g, const Rectangle<int>& thumbnailBounds)
+    {
+        g.setColour (Colours::darkgrey);
+        g.fillRect (thumbnailBounds);
+        g.setColour (Colours::white);
+        g.drawFittedText ("No File Loaded", thumbnailBounds, Justification::centred, 1.0f);
+    }
+
+    void paintIfFileLoaded (Graphics& g, const Rectangle<int>& thumbnailBounds)
+    {
+        g.setColour (Colours::white);
+        g.fillRect (thumbnailBounds);
+     
+        g.setColour (Colours::red);
+     
+        thumbnail.drawChannels (g,
+                                thumbnailBounds,
+                                0.0,                                    // start time
+                                thumbnail.getTotalLength(),             // end time
+                                1.0f);                                  // vertical zoom
+    }
+
+    
+    GranularAudioSource granularAudioSource;
+    File granularSourceFile;
+    
+    AudioThumbnailCache thumbnailCache;
+    AudioThumbnail thumbnail;
+    AudioFormatManager formatManager;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (GranularSynthesizer)
+};

--- a/Source/GranularVoice.cpp
+++ b/Source/GranularVoice.cpp
@@ -1,0 +1,107 @@
+/*
+  ==============================================================================
+
+    GranularVoice.cpp
+    Created: 18 Dec 2019 5:05:09pm
+    Author:  Bennet Leff
+
+  ==============================================================================
+*/
+
+#include "GranularVoice.h"
+#include "GranularSound.h"
+
+GranularVoice::GranularVoice() {}
+GranularVoice::~GranularVoice() {}
+
+bool GranularVoice::canPlaySound (SynthesiserSound* sound)
+{
+    return dynamic_cast<const GranularSound*> (sound) != nullptr;
+}
+
+void GranularVoice::startNote (int midiNoteNumber, float velocity, SynthesiserSound* s, int /*currentPitchWheelPosition*/)
+{
+    if (auto* sound = dynamic_cast<const GranularSound*> (s))
+    {
+        pitchRatio = std::pow (2.0, (midiNoteNumber - sound->midiRootNote) / 12.0)
+                        * sound->sourceSampleRate / getSampleRate();
+
+        sourceSamplePosition = 0.0;
+        lgain = velocity;
+        rgain = velocity;
+
+        adsr.setSampleRate (sound->sourceSampleRate);
+        adsr.setParameters (sound->params);
+
+        adsr.noteOn();
+    }
+    else
+    {
+        jassertfalse; // this object can only play GranularSounds!
+    }
+}
+
+void GranularVoice::stopNote (float /*velocity*/, bool allowTailOff)
+{
+    if (allowTailOff)
+    {
+        adsr.noteOff();
+    }
+    else
+    {
+        clearCurrentNote();
+        adsr.reset();
+    }
+}
+
+void GranularVoice::pitchWheelMoved (int /*newValue*/) {}
+void GranularVoice::controllerMoved (int /*controllerNumber*/, int /*newValue*/) {}
+
+//==============================================================================
+void GranularVoice::renderNextBlock (AudioBuffer<float>& outputBuffer, int startSample, int numSamples)
+{
+    if (auto* playingSound = static_cast<GranularSound*> (getCurrentlyPlayingSound().get()))
+    {
+        auto& data = *playingSound->data;
+        const float* const inL = data.getReadPointer (0);
+        const float* const inR = data.getNumChannels() > 1 ? data.getReadPointer (1) : nullptr;
+
+        float* outL = outputBuffer.getWritePointer (0, startSample);
+        float* outR = outputBuffer.getNumChannels() > 1 ? outputBuffer.getWritePointer (1, startSample) : nullptr;
+
+        while (--numSamples >= 0)
+        {
+            auto pos = (int) sourceSamplePosition;
+            auto alpha = (float) (sourceSamplePosition - pos);
+            auto invAlpha = 1.0f - alpha;
+
+            // just using a very simple linear interpolation here..
+            float l = (inL[pos] * invAlpha + inL[pos + 1] * alpha);
+            float r = (inR != nullptr) ? (inR[pos] * invAlpha + inR[pos + 1] * alpha)
+                                       : l;
+
+            auto envelopeValue = adsr.getNextSample();
+
+            l *= lgain * envelopeValue;
+            r *= rgain * envelopeValue;
+
+            if (outR != nullptr)
+            {
+                *outL++ += l;
+                *outR++ += r;
+            }
+            else
+            {
+                *outL++ += (l + r) * 0.5f;
+            }
+
+            sourceSamplePosition += pitchRatio;
+
+            if (sourceSamplePosition > playingSound->length)
+            {
+                stopNote (0.0f, false);
+                break;
+            }
+        }
+    }
+}

--- a/Source/GranularVoice.h
+++ b/Source/GranularVoice.h
@@ -1,0 +1,53 @@
+/*
+  ==============================================================================
+
+    GranularVoice.h
+    Created: 18 Dec 2019 5:05:09pm
+    Author:  Bennet Leff
+
+    Code structure heavily borrows from Juce's SamplerVoice.
+  ==============================================================================
+*/
+
+#pragma once
+
+#include "../JuceLibraryCode/JuceHeader.h"
+
+//==============================================================================
+/**
+    A subclass of SynthesiserVoice that can play a GranularSound.
+    To use it, create a Synthesiser, add some GranularVoice objects to it, then
+    give it some GranularSound objects to play.
+*/
+class GranularVoice    : public SynthesiserVoice
+{
+public:
+    //==============================================================================
+    /** Creates a SamplerVoice. */
+    GranularVoice();
+
+    /** Destructor. */
+    ~GranularVoice() override;
+
+    //==============================================================================
+    bool canPlaySound (SynthesiserSound*) override;
+
+    void startNote (int midiNoteNumber, float velocity, SynthesiserSound*, int pitchWheel) override;
+    void stopNote (float velocity, bool allowTailOff) override;
+
+    void pitchWheelMoved (int newValue) override;
+    void controllerMoved (int controllerNumber, int newValue) override;
+
+    void renderNextBlock (AudioBuffer<float>&, int startSample, int numSamples) override;
+    using SynthesiserVoice::renderNextBlock;
+
+private:
+    //==============================================================================
+    double pitchRatio = 0;
+    double sourceSamplePosition = 0;
+    float lgain = 0, rgain = 0;
+
+    ADSR adsr;
+
+    JUCE_LEAK_DETECTOR (GranularVoice)
+};

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -8,17 +8,15 @@
 
 #include "MainComponent.h"
 
-#include "Sampler.h"
-
 //==============================================================================
 MainComponent::MainComponent()
-: sampler(keyboardState)
+: granularSynth(keyboardState)
 {
     keyboardComponent = std::make_unique<MidiKeyboardComponent>(keyboardState, MidiKeyboardComponent::horizontalKeyboard);
 
     setupMidi();
 
-    addAndMakeVisible(&sampler);
+    addAndMakeVisible(&granularSynth);
     
     addAndMakeVisible (keyboardComponent.get());
     
@@ -41,19 +39,19 @@ MainComponent::~MainComponent()
 }
 
 //==============================================================================
-void MainComponent::prepareToPlay (int samplesPerBlockExpected, double sampleRate)
+void MainComponent::prepareToPlay (int samplesPerBlockExpected, double granularSynthate)
 {
-    sampler.prepareToPlay (samplesPerBlockExpected, sampleRate);
+    granularSynth.prepareToPlay (samplesPerBlockExpected, granularSynthate);
 }
 
 void MainComponent::getNextAudioBlock (const AudioSourceChannelInfo& bufferToFill)
 {
-    sampler.getNextAudioBlock (bufferToFill);
+    granularSynth.getNextAudioBlock (bufferToFill);
 }
 
 void MainComponent::releaseResources()
 {
-    sampler.releaseResources();
+    granularSynth.releaseResources();
 }
 
 //==============================================================================
@@ -68,7 +66,7 @@ void MainComponent::paint (Graphics& g)
 void MainComponent::resized()
 {
     midiInputList.setBounds (200, 10, getWidth() - 210, 20);
-    sampler.setBounds(10, 30, getWidth() - 20, 170);
+    granularSynth.setBounds(10, 30, getWidth() - 20, 170);
     keyboardComponent->setBounds (10,  210, getWidth() - 20, getHeight() - 50);
     setSample.setBounds(10, 10, 100, 20);
 
@@ -79,14 +77,14 @@ void MainComponent::setMidiInput (int index)
 {
     auto list = MidiInput::getDevices();
  
-    deviceManager.removeMidiInputCallback (list[lastInputIndex], sampler.getMidiCollector()); // [13]
+    deviceManager.removeMidiInputCallback (list[lastInputIndex], granularSynth.getMidiCollector()); // [13]
     
     auto newInput = list[index];
  
     if (! deviceManager.isMidiInputEnabled (newInput))
         deviceManager.setMidiInputEnabled (newInput, true);
  
-    deviceManager.addMidiInputCallback (newInput, sampler.getMidiCollector()); // [12]
+    deviceManager.addMidiInputCallback (newInput, granularSynth.getMidiCollector()); // [12]
     midiInputList.setSelectedId (index + 1, dontSendNotification);
  
     lastInputIndex = index;
@@ -132,6 +130,6 @@ void MainComponent::setSampleButtonClicked()
     if (chooser.browseForFileToOpen())
     {
         auto file = chooser.getResult();
-        sampler.setSourceFile(file);
+        granularSynth.setSourceFile(file);
     }
 }

--- a/Source/MainComponent.h
+++ b/Source/MainComponent.h
@@ -10,8 +10,8 @@
 
 #include "../JuceLibraryCode/JuceHeader.h"
 
-#include "Sampler.h"
-#include "SynthAudioSource.h"
+#include "GranularSynthesizer.h"
+#include "GranularAudioSource.h"
 
 //==============================================================================
 /*
@@ -62,7 +62,7 @@ private:
     /*
      * Audio Components
      */
-    Sampler sampler;
+    GranularSynthesizer granularSynth;
     
     std::unique_ptr<MidiKeyboardComponent> keyboardComponent;
     MidiKeyboardState keyboardState;


### PR DESCRIPTION
Created quite a few classes to which effectively replicate the Sampler implementation. Additionally, I've created custom `SynthesiserSound` and `SynthesiserVoice` classes for the Granular Synthesizer. These can be modified to permit more flexible design.